### PR TITLE
Fix spacing issue

### DIFF
--- a/assets/css/application-specific.css
+++ b/assets/css/application-specific.css
@@ -242,11 +242,11 @@ ul li a:hover {
 
 .questions-area {
     margin-right: 3%;
-    width: 66%;
+    width: 67%;
 }
 
 .links-area {
-    width: 31%;
+    width: 30%;
 }
 
 .opacity75 {


### PR DESCRIPTION
On my computer (Firefox on Fedora) the text for one of the FAQ questions overflows to the next list element; these changes fix that issue.

[Before](https://i.imgur.com/iDsFuzc.png)

[After](https://i.imgur.com/XYAmaqL.png)
